### PR TITLE
feat(db): add persistent activities (SQLAlchemy)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+SQLAlchemy>=1.4
+alembic

--- a/src/app.py
+++ b/src/app.py
@@ -123,6 +123,5 @@ def unregister_from_activity(activity_name: str, email: str, db: Session = Depen
         raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
     activity.participants.remove(participant)
-    db.add(activity)
     db.commit()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -107,7 +107,6 @@ def signup_for_activity(activity_name: str, email: str, db: Session = Depends(ge
         participant = Participant(email=email)
         db.add(participant)
     activity.participants.append(participant)
-    db.add(activity)
     db.commit()
     return {"message": f"Signed up {email} for {activity_name}"}
 

--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,7 @@ def signup_for_activity(activity_name: str, email: str, db: Session = Depends(ge
 
     if not participant:
         participant = Participant(email=email)
+        db.add(participant)
     activity.participants.append(participant)
     db.add(activity)
     db.commit()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,51 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy import Column, Integer, String, Text, DateTime, Table, ForeignKey
+from sqlalchemy.orm import relationship
+import os
+from datetime import datetime
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./rems_dev.db")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if "sqlite" in DATABASE_URL else {})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+# Association table for many-to-many between activities and participants
+activity_participant = Table(
+    "activity_participant",
+    Base.metadata,
+    Column("activity_id", Integer, ForeignKey("activities.id"), primary_key=True),
+    Column("participant_id", Integer, ForeignKey("participants.id"), primary_key=True),
+)
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), unique=True, index=True, nullable=False)
+    description = Column(Text, default="")
+    schedule = Column(String(200), default="")
+    max_participants = Column(Integer, default=0)
+    participants = relationship("Participant", secondary=activity_participant, back_populates="activities")
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "schedule": self.schedule,
+            "max_participants": self.max_participants,
+            "participants": [p.email for p in self.participants]
+        }
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(200), unique=True, index=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    activities = relationship("Activity", secondary=activity_participant, back_populates="participants")
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
This PR introduces SQLAlchemy models for Activity and Participant, a DB helper (`src/db.py`), and updates `src/app.py` to use the database for activities, signup, and unregister. It also seeds a few default activities on first run and updates `requirements.txt` to include SQLAlchemy and Alembic.

Highlights:
- `src/db.py`: Engine, session, models, and init helper
- `src/app.py`: Depends on DB session, endpoints use DB, seed on startup
- `requirements.txt`: adds SQLAlchemy and alembic

Please review and let me know any changes. This PR is intentionally focused and small so we can iterate.